### PR TITLE
Use persistent connections in frontend

### DIFF
--- a/kubernetes/nginx/frontend.conf
+++ b/kubernetes/nginx/frontend.conf
@@ -1,9 +1,11 @@
 upstream hello {
     server hello.default.svc.cluster.local;
+    keepalive 2;
 }
 
 upstream auth {
     server auth.default.svc.cluster.local;
+    keepalive 2;
 }
 
 server {
@@ -13,6 +15,9 @@ server {
     ssl_certificate     /etc/tls/cert.pem;
     ssl_certificate_key /etc/tls/key.pem;
 
+    proxy_http_version 1.1;
+    proxy_set_header Connection "";
+    
     location / {
         proxy_pass http://hello;
     }
@@ -20,4 +25,5 @@ server {
     location /login {
         proxy_pass http://auth;
     }
+
 }


### PR DESCRIPTION
This is a workaround for Scope not showing short-lived connections properly.

With this patch and using [vegeta](https://github.com/tsenart/vegeta) (which uses persistent connections) instead of curl to generate some load, I get the expected visualization:

<img width="1744" alt="screen shot 2016-04-28 at 19 25 50" src="https://cloud.githubusercontent.com/assets/2362916/14897304/6cd7a908-0d79-11e6-94ae-dfad51eb4067.png">

(This is a tailored local deployment, the kubernetes containers won't show in a not installation).

We will improve the tracking of short-lived connections for Scope 0.16.
